### PR TITLE
usar https para submodulo no lugar de ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/malt"]
-	path = themes/malt
-	url = git@github.com:grupydf/malt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/malt"]
+	path = themes/malt
+	url = https://github.com/grupydf/malt.git


### PR DESCRIPTION
usar https para submodulo no lugar de ssh, isso evita toda a parte chata de configurar a chave publica e privada para conseguir clonar e colaborar com o projeto.
